### PR TITLE
Fixes #51 #52 #55

### DIFF
--- a/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/BadgeDaoImpl.java
+++ b/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/BadgeDaoImpl.java
@@ -35,25 +35,25 @@ public class BadgeDaoImpl implements BadgeDao{
 
     @Override
     public void save(Badge badge) {
-     //   if (findById(badge.getId()) != null) {
-      //      try {
-      //          entityManager.merge(badge);
-     //       } catch (Exception e) {
-     //           throw new DaoLayerException(e.getMessage());
-      //      }
-      //  } else {
+        if (findById(badge.getId()) != null) {
+           try {
+               entityManager.merge(badge);
+            } catch (Exception e) {
+                throw new DaoLayerException(e.getMessage());
+            }
+        } else {
             try {
                 entityManager.persist(badge);
             } catch (Exception e) {
                 throw new DaoLayerException(e.getMessage());
             }
-       // }
+        }
     }
 
     @Override
     public void delete(Badge badge) {
         try {
-            entityManager.remove(badge);
+            entityManager.remove(findById(badge.getId()));
         } catch (Exception e) {
             throw new DaoLayerException(e.getMessage());
         }

--- a/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/BadgeDaoImpl.java
+++ b/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/BadgeDaoImpl.java
@@ -35,11 +35,19 @@ public class BadgeDaoImpl implements BadgeDao{
 
     @Override
     public void save(Badge badge) {
-        try {
-            entityManager.persist(badge);
-        } catch (Exception e) {
-            throw new DaoLayerException(e.getMessage());
-        }
+     //   if (findById(badge.getId()) != null) {
+      //      try {
+      //          entityManager.merge(badge);
+     //       } catch (Exception e) {
+     //           throw new DaoLayerException(e.getMessage());
+      //      }
+      //  } else {
+            try {
+                entityManager.persist(badge);
+            } catch (Exception e) {
+                throw new DaoLayerException(e.getMessage());
+            }
+       // }
     }
 
     @Override

--- a/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/BadgeDaoImpl.java
+++ b/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/BadgeDaoImpl.java
@@ -6,6 +6,9 @@
 package cz.fi.muni.pa165.seminar.pkmnleague.dao;
 
 import cz.fi.muni.pa165.seminar.pkmnleague.domain.Badge;
+import cz.fi.muni.pa165.seminar.pkmnleague.utils.DaoLayerException;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -23,22 +26,38 @@ public class BadgeDaoImpl implements BadgeDao{
 
     @Override
     public Badge findById(int id) {
-        return entityManager.find(Badge.class, id);
+        try {
+            return entityManager.find(Badge.class, id);
+        } catch (Exception e) {
+            throw new DaoLayerException(e.getMessage());
+        }
     }
 
     @Override
     public void save(Badge badge) {
-        entityManager.persist(badge);
+        try {
+            entityManager.persist(badge);
+        } catch (Exception e) {
+            throw new DaoLayerException(e.getMessage());
+        }
     }
 
     @Override
     public void delete(Badge badge) {
-        entityManager.remove(badge);
+        try {
+            entityManager.remove(badge);
+        } catch (Exception e) {
+            throw new DaoLayerException(e.getMessage());
+        }
     }
 
     @Override
     public List<Badge> findAll() {
-        return entityManager.createQuery("select b from Badge b", Badge.class).getResultList();
+        try {
+            return entityManager.createQuery("select b from Badge b", Badge.class).getResultList();
+        } catch (Exception e) {
+            throw new DaoLayerException(e.getMessage());
+        }
     }
 
  

--- a/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/GymDaoImpl.java
+++ b/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/GymDaoImpl.java
@@ -49,7 +49,7 @@ public class GymDaoImpl implements GymDao{
     @Override
     public void delete(Gym gym) {
         try {
-            entityManager.remove(gym);
+            entityManager.remove(findById(gym.getId()));
         } catch (Exception e) {
             throw new DaoLayerException(e.getMessage());
         }

--- a/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/GymDaoImpl.java
+++ b/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/GymDaoImpl.java
@@ -31,10 +31,18 @@ public class GymDaoImpl implements GymDao{
 
     @Override
     public void save(Gym gym) {
-        try {
-            entityManager.persist(gym);
-        } catch (Exception e) {
-            throw new DaoLayerException(e.getMessage());
+        if (findById(gym.getId()) != null) {
+            try {
+                entityManager.merge(gym);
+            } catch (Exception e) {
+                throw new DaoLayerException(e.getMessage());
+            }
+        } else {
+            try {
+                entityManager.persist(gym);
+            } catch (Exception e) {
+                throw new DaoLayerException(e.getMessage());
+            }
         }
     }
 

--- a/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/GymDaoImpl.java
+++ b/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/GymDaoImpl.java
@@ -1,6 +1,7 @@
 package cz.fi.muni.pa165.seminar.pkmnleague.dao;
 
 import cz.fi.muni.pa165.seminar.pkmnleague.domain.Gym;
+import cz.fi.muni.pa165.seminar.pkmnleague.utils.DaoLayerException;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
@@ -15,27 +16,44 @@ import java.util.List;
  */
 @Repository
 public class GymDaoImpl implements GymDao{
-     @PersistenceContext
+
+    @PersistenceContext
     private EntityManager entityManager;
 
     @Override
     public Gym findById(int id) {
-        return entityManager.find(Gym.class, id);
+        try {
+            return entityManager.find(Gym.class, id);
+        } catch (Exception e) {
+            throw new DaoLayerException(e.getMessage());
+        }
     }
 
     @Override
     public void save(Gym gym) {
-        entityManager.persist(gym);
+        try {
+            entityManager.persist(gym);
+        } catch (Exception e) {
+            throw new DaoLayerException(e.getMessage());
+        }
     }
 
     @Override
     public void delete(Gym gym) {
-        entityManager.remove(gym);
+        try {
+            entityManager.remove(gym);
+        } catch (Exception e) {
+            throw new DaoLayerException(e.getMessage());
+        }
     }
 
     @Override
     public List<Gym> findAll() {
-        return entityManager.createQuery("select g from Gym g", Gym.class).getResultList();
+        try {
+            return entityManager.createQuery("select g from Gym g", Gym.class).getResultList();
+        } catch (Exception e) {
+            throw new DaoLayerException(e.getMessage());
+        }
     }
     
 }

--- a/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/PokemonDaoImpl.java
+++ b/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/PokemonDaoImpl.java
@@ -1,6 +1,7 @@
 package cz.fi.muni.pa165.seminar.pkmnleague.dao;
 
 import cz.fi.muni.pa165.seminar.pkmnleague.domain.Pokemon;
+import cz.fi.muni.pa165.seminar.pkmnleague.utils.DaoLayerException;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,21 +23,37 @@ public class PokemonDaoImpl implements PokemonDao {
 
     @Override
     public Pokemon findById(int id) {
-        return entityManager.find(Pokemon.class, id);
+        try {
+            return entityManager.find(Pokemon.class, id);
+        } catch (Exception e) {
+            throw new DaoLayerException(e.getMessage());
+        }
     }
 
     @Override
     public void save(Pokemon pokemon) {
-        entityManager.persist(pokemon);
+        try {
+            entityManager.persist(pokemon);
+        } catch (Exception e) {
+            throw new DaoLayerException(e.getMessage());
+        }
     }
 
     @Override
     public void delete(Pokemon pokemon) {
-        entityManager.remove(pokemon);
+        try {
+            entityManager.remove(pokemon);
+        } catch (Exception e) {
+            throw new DaoLayerException(e.getMessage());
+        }
     }
 
     @Override
     public List<Pokemon> findAll() {
-        return entityManager.createQuery("select p from Pokemon p", Pokemon.class).getResultList();
+        try {
+            return entityManager.createQuery("select p from Pokemon p", Pokemon.class).getResultList();
+        } catch (Exception e) {
+            throw new DaoLayerException(e.getMessage());
+        }
     }
 }

--- a/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/PokemonDaoImpl.java
+++ b/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/PokemonDaoImpl.java
@@ -32,10 +32,18 @@ public class PokemonDaoImpl implements PokemonDao {
 
     @Override
     public void save(Pokemon pokemon) {
-        try {
-            entityManager.persist(pokemon);
-        } catch (Exception e) {
-            throw new DaoLayerException(e.getMessage());
+        if (findById(pokemon.getId()) != null) {
+            try {
+                entityManager.merge(pokemon);
+            } catch (Exception e) {
+                throw new DaoLayerException(e.getMessage());
+            }
+        } else {
+            try {
+                entityManager.persist(pokemon);
+            } catch (Exception e) {
+                throw new DaoLayerException(e.getMessage());
+            }
         }
     }
 

--- a/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/PokemonDaoImpl.java
+++ b/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/PokemonDaoImpl.java
@@ -50,7 +50,7 @@ public class PokemonDaoImpl implements PokemonDao {
     @Override
     public void delete(Pokemon pokemon) {
         try {
-            entityManager.remove(pokemon);
+            entityManager.remove(findById(pokemon.getId()));
         } catch (Exception e) {
             throw new DaoLayerException(e.getMessage());
         }

--- a/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/TrainerDaoImpl.java
+++ b/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/TrainerDaoImpl.java
@@ -2,6 +2,7 @@ package cz.fi.muni.pa165.seminar.pkmnleague.dao;
 
 
 import cz.fi.muni.pa165.seminar.pkmnleague.domain.Trainer;
+import cz.fi.muni.pa165.seminar.pkmnleague.utils.DaoLayerException;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
@@ -18,26 +19,46 @@ public class TrainerDaoImpl implements TrainerDao {
 
     @Override
     public Trainer findById(int id) {
-        return entityManager.find(Trainer.class, id);
+        try {
+            return entityManager.find(Trainer.class, id);
+        } catch (Exception e) {
+            throw new DaoLayerException(e.getMessage());
+        }
     }
 
     @Override
     public void save(Trainer trainer) {
-        entityManager.persist(trainer);
+        try {
+            entityManager.persist(trainer);
+        } catch (Exception e) {
+            throw new DaoLayerException(e.getMessage());
+        }
     }
 
     @Override
     public void delete(Trainer trainer) {
-        entityManager.remove(trainer);
+        try {
+            entityManager.remove(trainer);
+        } catch (Exception e) {
+            throw new DaoLayerException(e.getMessage());
+        }
     }
 
     @Override
     public List<Trainer> findAll() {
-        return entityManager.createQuery("select t from Trainer t", Trainer.class).getResultList();
+        try {
+            return entityManager.createQuery("select t from Trainer t", Trainer.class).getResultList();
+        } catch (Exception e) {
+            throw new DaoLayerException(e.getMessage());
+        }
     }
 
     @Override
     public Trainer findByEmail(String email) {
-        return entityManager.createQuery("select t from Trainer t where t.email = ?1", Trainer.class).setParameter(1, email).getSingleResult();
+        try {
+            return entityManager.createQuery("select t from Trainer t where t.email = ?1", Trainer.class).setParameter(1, email).getSingleResult();
+        } catch (Exception e) {
+            throw new DaoLayerException(e.getMessage());
+        }
     }
 }

--- a/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/TrainerDaoImpl.java
+++ b/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/TrainerDaoImpl.java
@@ -28,10 +28,18 @@ public class TrainerDaoImpl implements TrainerDao {
 
     @Override
     public void save(Trainer trainer) {
-        try {
-            entityManager.persist(trainer);
-        } catch (Exception e) {
-            throw new DaoLayerException(e.getMessage());
+        if (findById(trainer.getId()) != null) {
+            try {
+                entityManager.merge(trainer);
+            } catch (Exception e) {
+                throw new DaoLayerException(e.getMessage());
+            }
+        } else {
+            try {
+                entityManager.persist(trainer);
+            } catch (Exception e) {
+                throw new DaoLayerException(e.getMessage());
+            }
         }
     }
 

--- a/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/TrainerDaoImpl.java
+++ b/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/TrainerDaoImpl.java
@@ -46,7 +46,7 @@ public class TrainerDaoImpl implements TrainerDao {
     @Override
     public void delete(Trainer trainer) {
         try {
-            entityManager.remove(trainer);
+            entityManager.remove(findById(trainer.getId()));
         } catch (Exception e) {
             throw new DaoLayerException(e.getMessage());
         }

--- a/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/utils/DaoLayerException.java
+++ b/pkmnleague-persistence/src/main/java/cz/fi/muni/pa165/seminar/pkmnleague/utils/DaoLayerException.java
@@ -1,0 +1,16 @@
+package cz.fi.muni.pa165.seminar.pkmnleague.utils;
+
+import org.springframework.dao.DataAccessException;
+
+/**
+ * @author dhanak @domhanak on 1/24/16.
+ */
+public class DaoLayerException extends DataAccessException {
+    public DaoLayerException(String msg) {
+        super(msg);
+    }
+
+    public DaoLayerException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/pkmnleague-persistence/src/test/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/BadgeDaoTest.java
+++ b/pkmnleague-persistence/src/test/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/BadgeDaoTest.java
@@ -32,6 +32,7 @@ public class BadgeDaoTest extends AbstractTestNGSpringContextTests {
     public void testSave() {
         Trainer leader = new Trainer("Misty", "misty@kanto.jp", "", new Date(1996, 1, 2));
         Gym gym = new Gym("Cerulean", PokemonType.WATER, leader);
+        Gym gym2 = new Gym("Pewter", PokemonType.WATER, leader);
 
         Trainer t = new Trainer("Ash", "satoshi@kanto.jp", "", new Date(0));
 
@@ -39,8 +40,14 @@ public class BadgeDaoTest extends AbstractTestNGSpringContextTests {
 
         badgeDao.save(badge);
 
-        Badge result = badgeDao.findById(badge.getId());
-        assertEquals(badge, result);
+        Badge resultCreate = badgeDao.findById(badge.getId());
+        assertEquals(badge, resultCreate);
+
+        badge.setGym(gym2);
+
+        badgeDao.save(badge);
+        Badge resultUpdate = badgeDao.findById(badge.getId());
+        assertEquals(badge, resultUpdate);
     }
 
     @Test

--- a/pkmnleague-persistence/src/test/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/GymDaoTest.java
+++ b/pkmnleague-persistence/src/test/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/GymDaoTest.java
@@ -54,6 +54,12 @@ public class GymDaoTest extends AbstractTestNGSpringContextTests {
 
         Gym result = gymDao.findById(testGym.getId());
         assertEquals(testGym, result);
+
+        testGym.setCity("Pewter");
+        gymDao.save(testGym);
+
+        Gym resultUpdate = gymDao.findById(testGym.getId());
+        assertEquals(resultUpdate.getCity(), "Pewter");
     }
 
     @Test

--- a/pkmnleague-persistence/src/test/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/PokemonDaoTest.java
+++ b/pkmnleague-persistence/src/test/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/PokemonDaoTest.java
@@ -37,6 +37,12 @@ public class PokemonDaoTest extends AbstractTestNGSpringContextTests {
 
         Pokemon result = pokemonDao.findById(pokemon.getId());
         assertEquals(pokemon, result);
+
+        pokemon.setLevel(10);
+        pokemonDao.save(pokemon);
+
+        Pokemon resultUpdate = pokemonDao.findById(pokemon.getId());
+        assertEquals(resultUpdate.getLevel(), 10);
     }
 
     @Test

--- a/pkmnleague-persistence/src/test/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/TrainerDaoTest.java
+++ b/pkmnleague-persistence/src/test/java/cz/fi/muni/pa165/seminar/pkmnleague/dao/TrainerDaoTest.java
@@ -34,6 +34,13 @@ public class TrainerDaoTest extends AbstractTestNGSpringContextTests {
 
         Trainer result = trainerDao.findById(trainer.getId());
         assertEquals(trainer, result);
+
+        trainer.setEmail("karik@kares.sk");
+        trainerDao.save(trainer);
+
+        Trainer resultUpdate = trainerDao.findById(trainer.getId());
+        assertEquals("karik@kares.sk", resultUpdate.getEmail());
+
     }
 
     @Test


### PR DESCRIPTION
This adds following to DAO Layer:
Makes DAO Layer throw DaoLayerException, which is an instance of DataAccessException.
Adds tests for update scenario of save() method on DAO layer.
Corrects delete() methods to check if entity that we want to remove exists in DB.
